### PR TITLE
Lock to zenroom v1.0.5 to avoid v1.1.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "Keypair",
     "Zencode",
     "Zenroom",
+    "badpassword",
     "encrypter",
     "keypairs",
     "zprocess"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-chai-friendly": "^0.5.0",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jsdoc": "^23.0.0",
+    "eslint-plugin-jsdoc": "^24.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/core": "^7.9.6",
     "js-base64": "^2.5.2",
-    "zenroom": "^1.0.5"
+    "zenroom": "1.0.5"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lorena-ssi/zenroom-lib",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "zenroom-lib is a javascript library to interact with the Zenroom Virtual Machine",
   "main": "src/index.js",
   "author": "Alex Puig",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/core": "^7.9.6",
     "js-base64": "^2.5.2",
-    "zenroom": "^1.1.0"
+    "zenroom": "^1.0.5"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,9 @@ module.exports = class Zen {
     if (this.isSilent) {
       this.ogWriteStdout = process.stdout.write.bind(process.stdout)
       this.ogWriteStdErr = process.stderr.write.bind(process.stderr)
+      /* istanbul ignore next */
       process.on('uncaughtException', function (err) {
+        /* istanbul ignore next */
         console.error((err && err.stack) ? err.stack : err)
       })
     }
@@ -39,6 +41,7 @@ module.exports = class Zen {
     return new Promise((resolve, reject) => {
       const log = []
       if (this.isSilent) {
+        /* istanbul ignore next */
         this.stdoutWrite = (data) => log.push({ stdout: data })
         this.stderrWrite = (data) => log.push({ stderr: data })
         process.stdout.write = this.stdoutWrite

--- a/test/zenroom.js
+++ b/test/zenroom.js
@@ -205,7 +205,7 @@ describe('Zenroom', function () {
       assert.equal(rnd.length, 8)
     })
 
-    it('10. Should create a random PIN: ', async () => {
+    it('11. Should create a random PIN: ', async () => {
       rnd = await z.randomPin()
       assert.isNotEmpty(rnd)
       assert.equal(rnd.length, 6)
@@ -213,7 +213,7 @@ describe('Zenroom', function () {
       assert.equal(rnd.length, 4)
     })
 
-    it('11. Should create a random DID: ', async () => {
+    it('12. Should create a random DID: ', async () => {
       rnd = await z.randomDID()
       assert.isNotEmpty(rnd)
       assert.equal(rnd.length, 32)

--- a/test/zenroom.js
+++ b/test/zenroom.js
@@ -15,7 +15,7 @@ const z = new Zen(true)
 describe('Zenroom', function () {
   // Keypairs.
   describe('Should work with silent false', async () => {
-    const z2 = new Zen(false)
+    const z2 = new Zen() // false is default
     const aliceKeypair2 = await z2.newKeyPair('Alice')
     assert(!z2.isSilent)
     assert.isNotEmpty(aliceKeypair2.Alice.keypair)


### PR DESCRIPTION
Zenroom v1.1.0 contains breaking changes (naughty-naughty, breaking semver), therefore we must lock to zenroom v1.0.5 in this version, otherwise we'll automatically pull the new version and things won't work.